### PR TITLE
Upgrade Rubocop to 1.23.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,7 @@ fail_fast: false
 
 repos:
   - repo: https://github.com/jumanjihouse/pre-commit-hooks
-    rev: 1.11.2
+    rev: 2.1.5
     hooks:
       - id: forbid-binary
         exclude: >
@@ -62,7 +62,6 @@ repos:
         entry: pre_commit_hooks/shellcheck
         types: [shell]
         args: [-e, SC1091]
-        additional_dependencies: [shellcheck]
 
       - id: shfmt
         name: shfmt (local)
@@ -70,10 +69,9 @@ repos:
         entry: pre_commit_hooks/shfmt
         types: [shell]
         args: ['-l', '-i', '2', '-ci']
-        additional_dependencies: [shfmt]
 
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.20.0
+    rev: v1.26.3
     hooks:
       - id: yamllint
         args: ['--format', 'parsable', '--strict']
@@ -90,13 +88,13 @@ repos:
       - id: flake8
 
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.7
+    rev: v1.1.10
     hooks:
       - id: forbid-crlf
       - id: forbid-tabs
 
   - repo: https://github.com/jorisroovers/gitlint
-    rev: v0.13.1
+    rev: v0.16.0
     hooks:
       - id: gitlint
         stages: [commit-msg]

--- a/fake_gem.gemspec
+++ b/fake_gem.gemspec
@@ -6,16 +6,12 @@ Gem::Specification.new do |s|
   s.description = 'pre-commit hooks for ruby projects'
   s.add_dependency 'bigdecimal' # needed by reek
   s.add_dependency 'fasterer', '0.9.0'
-  s.add_dependency 'reek', '6.0.3'
-  s.add_dependency 'rubocop', '1.21.0'
-  s.add_dependency 'rubocop-performance', '1.11.5'
-  s.add_dependency 'rubocop-rails', '2.12.2'
+  s.add_dependency 'reek', '6.0.6'
+  s.add_dependency 'rubocop', '1.23.0'
+  s.add_dependency 'rubocop-performance', '1.12.0'
+  s.add_dependency 'rubocop-rails', '2.12.4'
   s.add_dependency 'rubocop-rake', '0.6.0'
-  s.add_dependency 'rubocop-rspec', '2.5.0'
+  s.add_dependency 'rubocop-rspec', '2.6.0'
   s.bindir = 'pre_commit_hooks'
-  s.executables = [
-    'run-fasterer',
-    'run-reek',
-    'run-rubocop',
-  ]
+  s.executables = %w[run-fasterer run-reek run-rubocop]
 end


### PR DESCRIPTION
Upgrade Rubocop to 1.23.0. Plus other pre-commit hooks.
